### PR TITLE
modify subtitle url format

### DIFF
--- a/tedSubtitle.pl
+++ b/tedSubtitle.pl
@@ -132,7 +132,7 @@ print "Seems good, go on.\n";
 
 # Get subtitle content from TED.COM
 # my $subtitleUrl = "http://www.ted.com/talks/subtitles/id/$talkID/lang/$languageCode/format/text";  @A4D
-my $subtitleUrl = "http://www.ted.com/talks/$talkID/transcript?lang=$languageCode";                 #@A4A
+my $subtitleUrl = "http://www.ted.com/talks/$talkID/transcript?language=$languageCode";                 #@A4A
 print "Subtitle URL: $subtitleUrl\n";
 my $content = GetUrl($subtitleUrl);
 


### PR DESCRIPTION
in tedSubtitle.pl

your subtitleUrl is http://www.ted.com/talks/$talkID/transcript?lang=$languageCode
but http://www.ted.com/talks/$talkID/transcript?language=$languageCode is correct

for example:
http://www.ted.com/talks/tania_simoncelli_should_you_be_able_to_patent_a_human_gene/transcript?language=zh-tw
can find

http://www.ted.com/talks/tania_simoncelli_should_you_be_able_to_patent_a_human_gene/transcript?lang=zh-tw
can't find
